### PR TITLE
Fix bit pattern matching in mac_address generation

### DIFF
--- a/lib/uuid.ex
+++ b/lib/uuid.ex
@@ -826,9 +826,9 @@ defmodule Uniq.UUID do
     else
       _ ->
         # In lieu of a MAC address, we can generate an equivalent number of random bytes
-        <<head::7, _::1, tail::46>> = :crypto.strong_rand_bytes(6)
+        <<head::7, _::1, tail::40>> = :crypto.strong_rand_bytes(6)
         # Ensure the multicast bit is set, as per RFC 4122
-        <<head::7, 1::1, tail::46>>
+        <<head::7, 1::1, tail::40>>
     end
   end
 


### PR DESCRIPTION
This PR addresses an issue in the mac_address/0 function within the Uniq.UUID module. The previous implementation attempted to match 54 bits from a 48-bit (6-byte) random value, which lead to pattern match failures. This fix ensures that we're working with the correct number of bits.